### PR TITLE
fix setter uninstall failed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,9 +135,9 @@ export const useModel: UseModel = (name) => {
   const [, setState] = useState();
   const { state, actions, setters } = models[name];
   useEffect(() => {
-    const index = setters.length;
     setters.push(setState);
     return () => {
+      const index = setters.indexOf(setState)
       setters.splice(index, 1);
     };
   }, [setters]);


### PR DESCRIPTION
使用中发现当卸载setter函数时的顺序和注册setter函数的循序不一致时，会导致未使用setter卸载不掉